### PR TITLE
fix(vault-token-helper): use hashicorp tap for vault

### DIFF
--- a/Formula/vault-token-helper.rb
+++ b/Formula/vault-token-helper.rb
@@ -37,7 +37,7 @@ class VaultTokenHelper < Formula
     end
   end
 
-  depends_on "vault"
+  depends_on "hashicorp/tap/vault"
 
   def caveats; <<~EOS
     Run this to create the ~/.vault file. This will configure vault to use the token helper:


### PR DESCRIPTION
This should fix the issue https://github.com/joemiller/vault-token-helper/issues/67 and #4 
```
==> Fetching dependencies for joemiller/taps/vault-token-helper: vault
Error: vault has been disabled because it will change its license to BUSL on the next release! It was disabled on 2024-09-27.
```